### PR TITLE
ifex_ast: Remove type from Struct

### DIFF
--- a/ifex/model/ifex_ast.py
+++ b/ifex/model/ifex_ast.py
@@ -389,10 +389,6 @@ class Struct:
     description: Optional[str] = str()
     """ Specifies the description of the struct. """
 
-    # TODO: do we need type field in a struct?
-    type: Optional[str] = None
-    """ Specifies the type of the struct. """
-
     members: Optional[List[Member]] = field(default_factory=EmptyList)
     """ Contains a list of members of a given struct. """
 


### PR DESCRIPTION
This was a mistake in previous definitions.  There is no need to have a type field for structs since they are already grouped under the structs: parent node.