### PR TITLE
workflows: Add D-Bus to basic checks

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -51,3 +51,9 @@ jobs:
       - name: Run BAMM template
         run: |
           ifexgen vehicle_service_catalog/comfort-service.yml -d sds-bamm > bamm.out
+
+      - name: Run D-Bus generator
+        run: |
+          ifexgen_dbus vehicle_service_catalog/comfort-service.yml >d-bus.out
+          cat d-bus.out
+

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -15,11 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -V
-          pip install pyyaml
-          pip install pytest
-          pip install anytree
-          pip install jinja2
-          pip install dacite
+          pip install -r requirements.txt
 
       - name: Install ifex module
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs==22.1.0
 iniconfig==1.1.1
 Jinja2==3.1.2
-lxml
+lxml==4.9.3
 MarkupSafe==2.1.1
 packaging==21.3
 pluggy==1.0.0


### PR DESCRIPTION
Run D-Bus generator (on one file from VSC, like the others) as part of buildcheck

(Note that this workflow WILL FAIL until https://github.com/COVESA/vehicle_service_catalog/pull/49 is merged)  
EDIT: It is now merged.
