### PR TITLE
docs: Make README links work if viewed in code repository

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # IFEX Documentation Overview
 
-- Main specification with introduction, examples, and the syntax of the core IDL/model: [ifex-specification.md](./ifex-specification.md)
-- Tips and information for developers: [developers-manual.md](./developers-manual.md) (WIP)
-- There is also a [Frequently Asked Questions](FAQ.md) file
+- Main specification with introduction, examples, and the syntax of the core IDL/model: [ifex-specification.md](https://covesa.github.io/ifex/ifex-specification)
+- Tips and information for developers: [developers-manual.md](https://covesa.github.io/ifex/developers-manual) (WIP)
+- There is also a [Frequently Asked Questions](./FAQ.md) file
 
 ----
 #### Writing documentation


### PR DESCRIPTION
Author: Gunnar Andersson \<gunnar.andersson@mercedes-benz.com\>, MBition GmbH.

### Confusing links in README.md inside docs/

The links in README.md inside of docs/ work correctly when viewed through GitHub pages, but if someone looked directly at the README in the code repository, the links go to not-yet-generated documentation files, and this was not obvious.  Now, by linking directly to the published GitHub pages explicitly, the links will work also when viewed inside of the code repository.

----

The program was tested solely for our own use cases, which might differ from yours. 

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
