### PR TITLE
Define AST without inheriting Namespace

### DIFF
--- a/ifex/model/ifex_ast.py
+++ b/ifex/model/ifex_ast.py
@@ -633,10 +633,13 @@ class Namespace:
 
 
 @dataclass
-class AST(Namespace):
+class AST():
     """
     Dataclass used to represent root element in a IFEX AST.
-    Behaviour is inherited from Namespace class.
     """
-
-    pass
+    name: Optional[str] = str()              # Represents name of file.  Usually better to name the Namespaces and Interfaces
+    description: Optional[str] = str()
+    major_version: Optional[int] = None      # Version of file.  Usually better to version Interfaces, and Namespaces!
+    minor_version: Optional[int] = None      # ------ " ------
+    includes: Optional[List[Include]] = field(default_factory=EmptyList)
+    namespaces: Optional[List[Namespace]] = field(default_factory=EmptyList)


### PR DESCRIPTION
At an early stage, the top level was defined by a toplevel namespace.
However the specification/examples treats the top level slightly differently.
In the meantime, some of the code was tested by treating Namespace to top level node instead of the AST type and (in quite a sloppy way) just achieving that by inheriting Namespace.

This commit is an old fix that should have been pushed a long time ago. It brings things into order by clearly defining the file top-level (represented by the AST class) as an independent thing.

From here, we are back in sync with the _current_ formal specification, and we can from there proceed to make slight modifications - such as clarifying where the versioning should occur (it should be applied to an Interface, not on "file" level) and other quality improvements.
