### PR TITLE
protobuf/gRPC support (as input language)

### DIFF
--- a/ifex/model/ifex_ast.py
+++ b/ifex/model/ifex_ast.py
@@ -176,6 +176,7 @@ class Method:
     output: Optional[List[Argument]] = field(default_factory=EmptyList)
     """ Contains a list of the method output arguments. """
 
+    # FIXME return argument should be possible to have anonymous (no given name)
     returns: Optional[List[Argument]] = field(default_factory=EmptyList)
     """ Contains a list of the method return arguments. """
 

--- a/ifex/model/ifex_ast_introspect.py
+++ b/ifex/model/ifex_ast_introspect.py
@@ -71,6 +71,14 @@ def field_is_optional(field):
     """Check if the typing hint of a member field is Optional."""
     return is_optional(field.type)
 
+def is_any(type_indicator):
+    """Check if the type indicator is Any."""
+    return type_indicator is Any
+
+def field_is_any(field):
+    """Check if the typing hint of a member field is Any."""
+    return is_any(field.type)
+
 def is_list(type_indicator):
     """Check if the type indicator is List (Optional or not)"""
     # If type indicator is wrapped in Optional we must extract the inner "actual type":

--- a/other/protobuf/README.md
+++ b/other/protobuf/README.md
@@ -9,3 +9,14 @@
 - `protobuf_ast.py` - Dataclass definitions for a Protobuf AST
 - `protobuf_ast_construction.py` - Define helper functions that build AST nodes
 - `protobuf_to_ifex.py` - AST Model-to-model transformation Protobuf->IFEX
+
+## How to run
+
+For simple conversions or tests, the protobuf_to_ifex.py has a main method and can be run as a script directly. It will print out the 
+result as IFEX Core IDL in YAML text:
+
+```
+python protobuf_to_ifex.py <input.proto>
+```
+ 
+For developing on top of this module, for example in a direct translation to other format without the IFEX text format as an intermediiate:  Import and use the function `proto_ast_from_input(protofile)` followed by `protobuf_to_ifex(proto_ast)` on that result.  The latter returns an IFEX AST that can be further processed.

--- a/other/protobuf/README.md
+++ b/other/protobuf/README.md
@@ -1,0 +1,11 @@
+# Protobuf parser/input processing
+
+## Dependencies:
+- Lark parser framework
+
+## Files
+- `protobuf.grammar` - Protobuf syntax definition in Lark format
+- `protobuf_lark.py` - Input parser, creates Protobuf AST
+- `protobuf_ast.py` - Dataclass definitions for a Protobuf AST
+- `protobuf_ast_construction.py` - Define helper functions that build AST nodes
+- `protobuf_to_ifex.py` - AST Model-to-model transformation Protobuf->IFEX

--- a/other/protobuf/protobuf.grammar
+++ b/other/protobuf/protobuf.grammar
@@ -346,7 +346,7 @@ X_REPEATED: "repeated"
 X_OPTIONAL: "optional"
 
 # from spec: fieldOptions = fieldOption { ","  fieldOption }
-?fieldoptions: valueoption ( ","  valueoption )*
+fieldoptions: valueoption ( ","  valueoption )*
 
 # from spec: fieldOption = optionName "=" constant
 valueoption: OPTIONNAME "=" constant

--- a/other/protobuf/protobuf.grammar
+++ b/other/protobuf/protobuf.grammar
@@ -1,0 +1,451 @@
+# ============================================================
+# PROTOBUF LARK GRAMMAR
+# ============================================================
+#
+# (C) Writers of Protobuf specification (original grammar spec)
+# (C) 2024 MBition GmbH (Lark format, and changed/added parts)
+#     Author: Gunnar Andersson
+#
+# Grammar for Lark parser, derived from protobuf specification at:
+# https://protobuf.dev/reference/protobuf/proto3-spec
+#
+# Design notes:
+# -------------
+# There seemed to be not a single official and canonical grammar
+# file, only the definitions provided in the protobuf3 specification.
+# 
+# There were also other parser examples mentioned/linked at protobuf.com:
+# https://github.com/bufbuild/protobuf.com/tree/main/examples 
+# Those grammars don't seem to use the exact same names as the ones in the
+# specification.  I did not find a Lark-based one to reuse.  The other grammars
+# could have been reused, with a different parser framework, and/or after rework.
+# In the end, taking grammar from the specification and writing it in a Lark
+# way felt like an equivalent or lower effort.
+#
+#
+# Grammar format:
+# ---------------
+# 
+# Here we rewrite each rule in Lark syntax.  It tries to follow the EBNF from
+# the specification closely, but with the following comments: 
+#
+#  - The original rule names use CamelCase but they have here been modified to
+#    fit common Lark naming conventions: 
+#    - Composite rules are here converted to _lowercase_ only!
+#    - Terminals (Tokens) are convertd to UPPERCASE only
+#  - Some composite rules in the original grammar can be simplified
+#  into a single regexp Terminal definition.  This is done in some
+#  areas to reduce the complexity and depth of the rule set.
+#  If the regexp replaces the original rule completely, then it has been named
+#  as the original rule but UPPERCASE (which is the lark convention for
+#  terminal/regexp definitons).
+#
+#  - Next, we have added ? questionmark to some rules. This is a Lark feature
+#  that "inlines" that rule/token - if it has only one value (which is very
+#  common for many rules)  so that we don't need to iterate over it 
+#
+#  - There can be a few additional minor tweaks/changes to better suit the Lark
+#  principlesl 
+#
+#
+# Added grammar rules for Lark
+# ----------------------------
+#
+#  The way Lark works is that only rules and terminal/tokens are kept in the
+#  resulting parse-tree.  If a statement matches an explicit string specified
+#  in a rule, those words are considered 'syntax' that was matched to identify
+#  the statement type.  Those words won't be stored in the resulting parse tree.
+# 
+#  Example for import:  A EBNF like this:
+#
+#  >  import: "import" ("weak" | "public")? strlit ";"
+#
+#  The word "import" is thrown away because the resulting statement type (the
+#  name import before the colon) will be stored.  That's expected, and we don't
+#  need the word "import" to also be remembered.
+#
+#  The strlit will be stored with the token, because it is the content that
+#  matches a separate rule.
+# 
+#  However, the rule will match if `weak` or `public` was mentioned but
+#  since those are explicit words, "syntax" it won't store which explicit word
+#  was used. `weak` and `public` would be matched and then thrown away.  Since
+#  weak/public are keywords with semantic meaning here so we need the information
+#  to be carried into the parsed result.
+#
+#  We need therefore to separately name a token or rule for the recognition of
+#  weak/public so that the information is stored in the parse tree.  (Lark also
+#  provides a mechanism called an "alias" to achieve the same -- see Lark
+#  documentation)
+#
+#  We use a name starting with `x_` or `X_` in cases where we added a
+#  new/additional rule to the grammar from the specification.
+#
+#
+# Grammar organization
+# --------------------
+#
+# For each item there is a line "from spec: " which is the exact EBNF
+# definition provided by the specification.  After that follows the Lark
+# grammar rule(s).  Sections (titles) of the specification have also been kept
+# for each area.
+
+# ------------------------------------------------------------
+# Reminder EBNF syntax:
+# |   alternation
+# ()  grouping
+# []  option (zero or one time)
+# {}  repetition (any number of times)
+#
+# Reminder Lark syntax:
+# See Lark documentation, but it is similar to regular expressions for
+# grouping `()`, alternation `|` option `?` and repetition `*` / `+`
+
+
+# ============================================================
+# Start of Grammar definition
+# ============================================================
+
+# from spec: letter = "A" ... "Z" | "a" ... "z"
+# (UNUSED) letter: /[A-Za-z0-9_]+/
+
+# from spec: decimalDigit = "0" ... "9"
+# (UNUSED) decimaldigit: /[0-9]/
+
+# from spec: octalDigit = "0" ... "7"
+OCTALDIGIT: /[0-7]/
+
+# from spec: hexDigit = "0" ... "9" | "A" ... "F" | "a" ... "f"
+HEXDIGIT: /[0-9A-Fa-f]/
+
+# Identifiers
+# -----------
+
+# from spec: ident = letter { letter | decimaldigit | "_" }
+# Lark: Simplified to a plain regexp
+IDENT: /[A-Za-z0-9_]+/
+
+# from spec: fullIdent = IDENT { "." IDENT }
+?fullident: IDENT ( "." IDENT )*
+# Lark: Also, a simpler version using a single regexp
+FULLIDENT: /[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*/
+
+# from spec: messageName = IDENT
+?messagename.1: IDENT
+
+# from spec: enumName = IDENT
+?enumname: IDENT
+
+# from spec: fieldName = IDENT
+?fieldname: IDENT
+
+# from spec: oneofName = IDENT
+?oneofname: IDENT
+
+# from spec: mapName = IDENT
+?mapname: IDENT
+
+# from spec: serviceName = IDENT
+?servicename: IDENT
+
+# from spec: rpcName = IDENT
+?rpcname: IDENT
+
+# NOTE: I don't think we can distinguish between message and enum
+# types atm.  The syntax is the same, and they are used in
+# similar/same places?  If required, cross referencing the enumname
+# with a definition ('enum' rule/object) seems to be needed
+# And similarly messagename as used in a 'message' definition.
+
+# ...so we may as well inline them
+
+# from spec: messageType = [ "." ] { ident "." } messageName
+# Lark: Changed into a single regexp for easier processing
+# ?messagetype:  "."? (IDENT ".")* messagename
+MESSAGETYPE: /\.?([A-Za-z0-9_]+\.)*([A-Za-z0-9_]+)/
+
+# from spec: enumType = [ "." ] { ident "." } enumName
+?enumtype.1: "."? (IDENT ".")* enumname
+ENUMTYPE: /\.?([A-Za-z0-9_]+\.)*([A-Za-z0-9_]+)/
+DEFINEDTYPE: /\.?([A-Za-z0-9_]+\.)*([A-Za-z0-9_]+)/
+
+# Integer Literals
+# ----------------
+
+# from spec: intLit = decimalLit | octalLit | hexLit
+?intlit.2: INT | OCTALLIT | HEXLIT
+
+# from spec: decimalLit = [-] ( "1" ... "9" ) { decimalDigit }
+# Lark: Simplified to a plain regexp:
+DECIMALLIT.1: /-?[1-9][0-9]*/
+
+# Not sure why DECIMALLIT was so strictly defined as > 0 ??
+# Some failures in parsing where we have assignment to zero, so substituting INT pattern in those places
+INT.1: /-?[0-9]+/
+
+# from spec: octalLit = [-] "0" { octalDigit }
+# Lark: Simplified to a plain regexp:
+OCTALLIT.1: /-?0[0-7]*/
+
+# from spec: hexLit = [-] "0" ( "x" | "X" ) hexDigit { hexDigit }
+# Lark: Simplified to a plain regexp
+HEXLIT.1: /-?0x[0-9A-Fa-f]+/
+
+# Floating-point Literals
+# -----------------------
+
+# from spec: floatLit = [-] ( decimals "." [ decimals ] [ exponent ] | decimals exponent | "."decimals [ exponent ] ) | "inf" | "nan"
+# exponent: ("e" | "E")? ("+" | "-")? decimals
+# Lark: Split into a few regexps to keep complexity down.
+# (still, the original EBNF looks strange - is it really correct?)
+#floatlit.1: FLOATLIT1 | FLOATLIT2 | FLOATLIT3 | FLOATLIT4
+#FLOATLIT1.5: /-?[0-9]+\.([0-9]*[eE][+-]?[0-9]+)/
+#FLOATLIT2.4: /-?\.[0-9]*([eE]?[+-]?[0-9]+)?/
+#FLOATLIT3.3: /-?[0-9]+\.[0-9]+/
+# The spec seem to allow also this format starting with "." but no decimals following it
+#FLOATLIT4.2: /inf|nan/
+
+# Combine the regexes, let's see if it works:
+FLOATLIT.1: /-?[0-9]+\.([0-9]*[eE][+-]?[0-9]+)?|-?\.[0-9]*([eE]?[+-][0-9]+)?|inf|nan/
+
+# from spec: decimals  = [-] decimalDigit { decimalDigit }
+# Lark: Simplified to a plain regexp
+# comment: decimallit above is required to start with a 1, not
+# zero, but in definition of floatingpoint, it is using
+# "decimaldigit" which would allow a leading zero?
+?decimals: /-?[0-9]+/
+
+# from spec: exponent  = ( "e" | "E" ) [ "+" | "-" ] decimals
+exponent: ("e" | "E") ("+" | "-")? decimals
+
+# Boolean
+# -------
+
+# from spec: boolLit = "true" | "false"
+# Lark: Simplified to a plain regexp.  Prio 1 to prefer this over IDENT
+BOOLLIT.1: /true|false/
+
+# String Literals 
+
+# from spec: charValue = hexEscape | octEscape | charEscape | unicodeEscape | unicodeLongEscape | /[^\0\n\\]/
+# Not sure what the intention is with the regexp at the end.
+# It looks like it matches NOT null, NOT newline and NOT backslash?
+# ... but this rule needs the ability to match any string as far as
+# I can see => hence changed to X_CHARSTRINGVAL pattern instead
+?charvalue: hexescape | octescape | charescape | unicodeescape | unicodelongescape | X_CHARSTRING
+X_CHARSTRING: /[^\0\n\\"]+/
+
+# from spec: hexEscape = '\' ( "x" | "X" ) hexDigit [ hexDigit ]
+# comment: Is it correct to only allow max two digits?
+hexescape: "\\" ( "x" | "X" ) HEXDIGIT HEXDIGIT?
+
+# from spec: octEscape = '\' octalDigit [ octalDigit [ octalDigit ] ]
+octescape: "\\" OCTALDIGIT OCTALDIGIT? OCTALDIGIT?
+
+# from spec: charEscape = '\' ( "a" | "b" | "f" | "n" | "r" | "t" | "v" | '\' | "'" | '"' )
+# Lark: Simplified to a plain regexp
+charescape: /[\][abfnrtv\'"]/
+
+# from spec: unicodeEscape = '\' "u" hexDigit hexDigit hexDigit hexDigit
+unicodeescape: "\\u" HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
+
+# from spec: unicodeLongEscape = '\' "U" ( "000" hexDigit hexDigit hexDigit hexDigit hexDigit  | "0010" hexDigit hexDigit hexDigit hexDigit
+unicodelongescape: "\\U" ("000" HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT | "0010" HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT)
+
+# Emptystatement
+# --------------
+
+# from spec: emptyStatement = ";"
+?emptystatement: ";"
+
+# Constant 
+# --------
+
+# from spec:  constant = fullIdent | ( [ "-" | "+" ] intLit ) | ( [ "-" | "+" ] floatLit ) | strLit | boolLit | messageValue
+# comment: The spec looks buggy because intLit already allows for a - sign in front of it, so why not allow a + sign on all intlits also?
+# => We deviate from spec slightly here, because a prefixed "+" is unlikely to happen in input anyway:
+# comment2: Why can't a constant be a Hexadecimal literal??
+#?constant: BOOLLIT | FLOATLIT | DECIMALLIT | HEXLIT | fullident | intlit | strlit | messagevalue
+?constant: INT | BOOLLIT | FLOATLIT | HEXLIT | fullident | strlitsingle | intlit | messagevalue
+#STRLITSINGLE: /"[A-Za-z0-9_.]+"|'[A-Za-z0-9_.]+'/
+
+# from spec: strLit = strLitsingle { strLitsingle }
+?strlit: strlitsingle+
+
+# from spec: strLitsingle = ( "'" { charValue } "'" ) |  ( '"' { charValue } '"' )
+?strlitsingle: "'" charvalue "'" | "\"" charvalue "\""
+
+
+# from spec: "MessageValue is defined in the Text Format Language Specification.  "
+# from text format spec: MessageValue = "{", Message, "}" | "<", Message, ">" ;
+?messagevalue: "{" message "}" | "<" message ">"
+
+# Syntax
+# ------
+
+# from spec: syntax = "syntax" "=" ("'" "proto3" "'" | '"' "proto3" '"') ";"
+# comment: We only support spec version 3 here, (and for that
+# version only the string "proto3" is allowed)
+syntax: "syntax" "=" ("'" | "\"") "proto3" ("'" | "\"") ";"
+
+# Import Statement
+# ----------------
+
+# from spec: import = "import" [ "weak" | "public" ] strlit ";"
+import: "import" X_IMPORTMODIFIER? strlit ";"
+X_IMPORTMODIFIER: /weak|public/
+
+# Package
+# -------
+
+# from spec: package = "package" fullIdent ";"
+package: "package" FULLIDENT ";"
+
+# Option
+# ------
+
+# from spec: option = "option" optionName  "=" constant ";"
+option: "option" OPTIONNAME "=" constant ";"
+
+# from spec: optionName = optionNamePart { "." optionNamePart }
+# from spec: optionNamePart = { IDENT | "(" ["."] fullident ")" }
+#
+# Lark alternative:
+#?optionname: optionnamepart ( "." optionnamepart )*
+#?optionnamepart: IDENT | "(" "."? fullident ")"
+#
+# Lark final: optionname combined to a single regexp for easier processing
+OPTIONNAME: /[A-Za-z0-9_]+|
+             \([A-Za-z0-9_]+\)|
+             \(\.?([A-Za-z0-9_]+\.)*[A-Za-z0-9_]+\)
+            /x
+
+# Fields
+# ------
+
+# from spec: type = "double" | "float" | "int32" | "int64" | "uint32" | "uint64" | "sint32" | "sint64" | "fixed32" | "fixed64" | "sfixed32" | "sfixed64" | "bool" | "string" | "bytes" | messagetype | enumtype
+# comment: We have to capture the actual type that is used - easiest is to match them with regexp.  It's not enough since we also have composite rules messagetype and enumtype to take care of - so an extra X_BUILTINTYPE added, and it is also prioritized (.1) over messagetype which might otherwise match
+# NOTE: 'messagetype' and 'enumtype' are defined identically, and also only used to define 'type' here.
+# Therefore, it is easier to combine them => let's call it DEFINEDTYPE
+?type: X_BUILTINTYPE | DEFINEDTYPE
+X_BUILTINTYPE.1: /(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64|bool|string|bytes)/
+
+# from spec: fieldNumber = intLit;
+# comment: There should not be a semicolon there, I think?
+?fieldnumber: intlit
+
+# Normal Field
+# ------------
+
+# from spec: field = [ "repeated" ] type fieldName "=" fieldNumber [ "[" fieldOptions "]" ] ";"
+field: X_REPEATED? type fieldname "=" fieldnumber ( "[" fieldoptions "]" )?  ";"
+X_REPEATED: "repeated"
+
+# from spec: fieldOptions = fieldOption { ","  fieldOption }
+?fieldoptions: valueoption ( ","  valueoption )*
+
+# from spec: fieldOption = optionName "=" constant
+valueoption: OPTIONNAME "=" constant
+
+# Oneof and Oneof Field
+# ---------------------
+
+# from spec: oneof = "oneof" oneofName "{" { option | oneofField } "}"
+oneof: "oneof" oneofname "{" ( option | oneoffield )+ "}"
+
+# from spec: oneofField = type fieldName "=" fieldNumber [ "[" fieldOptions "]" ] ";"
+oneoffield: type fieldname "=" fieldnumber ( "[" fieldoptions "]" )? ";"
+
+# Map Field
+# ---------
+
+# from spec: mapField = "map" "<" keyType "," type ">" mapName "=" fieldNumber [ "[" fieldOptions "]" ] ";"
+mapfield: "map" "<" keytype "," type ">" mapname "=" fieldnumber ("[" fieldoptions "]")? ";"
+
+# from spec: keyType = "int32" | "int64" | "uint32" | "uint64" | "sint32" | "sint64" | "fixed32" | "fixed64" | "sfixed32" | "sfixed64" | "bool" | "string"
+keytype: "int32" | "int64" | "uint32" | "uint64" | "sint32" | "sint64" | "fixed32" | "fixed64" | "sfixed32" | "sfixed64" | "bool" | "string"
+
+# Reserved
+# --------
+
+# from spec: reserved = "reserved" ( ranges | strFieldNames ) ";"
+reserved: "reserved" ( ranges | strfieldnames ) ";"
+
+# from spec: ranges = range { "," range }
+?ranges: range ( "," range )*
+
+# from spec: range =  intLit [ "to" ( intLit | "max" ) ]
+range:  intlit ( "to" ( intlit | X_MAX ) )?
+X_MAX: "max" 
+
+# from spec: strFieldNames = strFieldName { "," strFieldName }
+?strfieldnames: strfieldname ( "," strfieldname )*
+
+# from spec: strFieldName = "'" fieldName "'" | '"' FieldName '"'
+?strfieldname: ("'" | "\"") fieldname ("'" | "\"")
+
+# Top Level Definitions
+# ---------------------
+
+# Enum Definition
+# ---------------
+
+# from spec: enum = "enum" enumName enumBody
+enum: "enum" enumname enumbody
+
+# from spec: enumBody = "{" { option | enumField | emptystatement | reserved } "}"
+?enumbody: "{" ( enumfield | reserved | enumoption )* "}"
+
+# NOTE: Something buggy when using the current option definition, creating a new one for option-in-enum here
+?enumoption: "option" OPTIONNAME "=" constant ";"
+
+# from spec: enumField = IDENT "=" [ "-" ] intLit [ "[" enumValueOption { ","  enumValueOption } "]" ]";"
+# comment: As noted before, intlit already allows for a "-" minus sign so not sure why it is included here again.
+# enumfield: IDENT "=" "-"? intlit ( "[" enumvalueoption ( ","  enumvalueoption )* "]" )? ";"
+# Lark optimization: enumvalueoption and fieldoptions look the same - just reuse a common rule "valueoption"
+enumfield: IDENT "=" "-"? intlit ( "[" valueoption ( ","  valueoption )* "]" )? ";"
+
+# from spec: enumValueOption = optionName "=" constant
+# Lark: Reuse 'valueoption' (defined above) as common for fieldoption and enumvalueoption
+
+# Message Definition
+# ------------------
+
+# from spec: message = "message" messageName messageBody
+message: "message" messagename messagebody
+
+# from spec: messageBody = "{" { field | enum | message | option | oneof | mapField | reserved | emptyStatement } "}"
+messagebody: "{" ( field | enum | message | option | oneof | mapfield | reserved | emptystatement )* "}"
+
+# Service Definition
+# ------------------
+
+# from spec: service = "service" serviceName "{" { option | rpc | emptyStatement } "}"
+service: "service" servicename "{" ( option | rpc | emptystatement )* "}"
+
+# from spec: rpc = "rpc" rpcName "(" [ "stream" ] messageType ")" "returns" "(" [ "stream" ] messageType ")" (( "{" {option | emptyStatement } "}" ) | ";")
+rpc: "rpc" rpcname "(" X_STREAM? MESSAGETYPE ")" "returns" "(" X_STREAM? MESSAGETYPE ")" (( "{" (option | emptystatement )* "}" ) | ";")
+X_STREAM: "stream"
+
+# Proto File
+# ----------
+
+# from spec: proto = syntax { import | package | option | topLevelDef | emptyStatement }
+?proto: syntax ( import | package | option | topleveldef | emptystatement )*
+
+# from spec: topLevelDef = message | enum | service
+?topleveldef: message | enum | service
+
+
+# Lark-specific adjustements
+# --------------------------
+#
+# Lark requires the root to use the rule name "start"
+?start: proto
+
+# Reuse definition of whitespace
+%import common (WS)
+
+# Whitespace is implicitly assumed for all the above rules, in
+# other words it must be ignored by the parser.
+%ignore WS

--- a/other/protobuf/protobuf.grammar
+++ b/other/protobuf/protobuf.grammar
@@ -398,7 +398,7 @@ X_MAX: "max"
 enum: "enum" enumname enumbody
 
 # from spec: enumBody = "{" { option | enumField | emptystatement | reserved } "}"
-?enumbody: "{" ( enumfield | reserved | enumoption )* "}"
+enumbody: "{" ( enumfield | reserved | enumoption )* "}"
 
 # NOTE: Something buggy when using the current option definition, creating a new one for option-in-enum here
 ?enumoption: "option" OPTIONNAME "=" constant ";"

--- a/other/protobuf/protobuf.grammar
+++ b/other/protobuf/protobuf.grammar
@@ -338,8 +338,12 @@ X_BUILTINTYPE.1: /(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|
 # ------------
 
 # from spec: field = [ "repeated" ] type fieldName "=" fieldNumber [ "[" fieldOptions "]" ] ";"
-field: X_REPEATED? type fieldname "=" fieldnumber ( "[" fieldoptions "]" )?  ";"
+field: X_OPTIONAL? X_REPEATED? type fieldname "=" fieldnumber ( "[" fieldoptions "]" )?  ";"
 X_REPEATED: "repeated"
+# comment: Weirdly the "optional" keyword is (as of this time) not mentioned in the
+# syntax rules for fields in the proto3 spec.  It is however implied byt the
+# separate chapter named "Field Presence".
+X_OPTIONAL: "optional"
 
 # from spec: fieldOptions = fieldOption { ","  fieldOption }
 ?fieldoptions: valueoption ( ","  valueoption )*

--- a/other/protobuf/protobuf_ast.py
+++ b/other/protobuf/protobuf_ast.py
@@ -34,6 +34,7 @@ class Field:
     name: str
     datatype: str
     repeated: Optional[bool] = False
+    optional: Optional[bool] = False
     options: Optional[List[Option]] = None
 
 @dataclass

--- a/other/protobuf/protobuf_ast.py
+++ b/other/protobuf/protobuf_ast.py
@@ -75,7 +75,7 @@ class Enumeration:
 @dataclass
 class Message:
     name: str
-    enums: Optional[str] = None # A reference to an enum type, defined elsewhere
+    enums: Optional[List[Enumeration]] = None
     fields: Optional[List[Field]] = None
     messages: Optional[List["Message"]] = None
     options: Optional[List[Option]] = None

--- a/other/protobuf/protobuf_ast.py
+++ b/other/protobuf/protobuf_ast.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 MBition GmbH.
+# SPDX-License-Identifier: MPL-2.0
+
+# This file is part of the IFEX project
+
+# Node types to represent a Protobuf AST, similar to ifex_ast.py
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+# The protobuf syntax is different for options when they appear in
+# rpc/service/msg or in fields, but the actual content is the same (name and
+# value) so we can use a common type for them:
+@dataclass
+class Option:
+    name: str
+    value: str
+
+@dataclass
+class EnumField:
+    name: str
+    value: str
+    options: Optional[List[Option]] = None
+
+@dataclass
+class MapField:
+    name: str
+    keytype: str
+    valuetype: str
+    options: Optional[List[Option]] = None
+
+@dataclass
+class Field:
+    name: str
+    datatype: str
+    repeated: Optional[bool] = False
+    options: Optional[List[Option]] = None
+
+@dataclass
+class OneOf:
+    name: str
+    options: Optional[List[Option]]
+    # Note: Strictly speaking OneOf does not accept a normal field type because
+    # a normal field can have "repeated" keyword, which does not fit here.
+    # For the purpose of this definition, we leave that slight possibility as
+    # it is and accept the common Field definition here.
+    fields: List[Field]
+
+@dataclass
+class Import:
+    path: str
+    # Note: Only one of weak or public can be true
+    weak: Optional[bool] = False
+    public: Optional[bool] = False
+
+@dataclass
+class Range:
+    single_value: Optional[str]
+    range_start: Optional[int]
+    range_end: Optional[Union[int, str]] # str would be set to "max"
+
+@dataclass
+class Reserved:
+    ranges: Optional[List[Range]] = None
+    strfieldnames: Optional[List[str]] = None
+
+@dataclass
+class Enumeration:
+    name: str
+    fields: List[EnumField] = None
+    options: Optional[List[Option]] = None
+    reservations: Optional[List[Reserved]] = None
+
+@dataclass
+class Message:
+    name: str
+    enums: Optional[str] = None # A reference to an enum type, defined elsewhere
+    fields: Optional[List[Field]] = None
+    messages: Optional[List["Message"]] = None
+    options: Optional[List[Option]] = None
+    oneofs: Optional[List[OneOf]] = None
+    mapfields: Optional[List[MapField]] = None
+    reservations: Optional[List[Reserved]] = None
+
+@dataclass
+class RPC:
+    name: str
+    input: Optional[str] = None   # _Reference_ to a Message (not defining a NEW Message)
+    input_stream: Optional[bool] = False
+    returns: Optional[str] = None # (same as above)
+    return_stream: Optional[bool] = False
+    options: Optional[List[Option]] = None
+
+@dataclass
+class Service:
+    name: str
+    rpcs: List[RPC]
+    options: Optional[List[Option]] = None
+
+# Proto = top level root of the tree:
+@dataclass
+class Proto:
+    # NOTE! The grammar in the protobuf specification grammar allows MULTIPLE
+    # package statements - but it is not clear that this is valid.  If it is is
+    # the order and position in the file relevant?  The spec uses singular
+    # words when describing: quote: "The package specifier can be used to
+    # prevent name clashes between protocol message types".  For now, we limit
+    # it to one, and the parser will otherwise warn.
+    package: Optional[str] = None
+    imports: Optional[List[Import]] = None
+    options: Optional[List[Option]] = None
+    messages: Optional[List[Message]] = None
+    enums: Optional[List[Enumeration]] = None
+    services: Optional[List[Service]] = None
+    #syntax: not used (always = 'proto3' anyway)

--- a/other/protobuf/protobuf_ast_construction.py
+++ b/other/protobuf/protobuf_ast_construction.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 MBition GmbH.
+# SPDX-License-Identifier: MPL-2.0
+
+# This file is part of the IFEX project
+
+"""
+Light-weight support functions for creating the Protobuf tree from program code,
+likely to be used in Protobuf-to/from-IFEX model conversions.
+"""
+
+# See ifex_ast_construction.py for a more in-depth description of what this
+# is and why.  It follows the exact same pattern.
+
+from dataclasses import is_dataclass
+from ifex.model.type_checking_constructor_mixin import add_constructor
+import protobuf_ast
+
+def add_constructors_to_protobuf_ast_model() -> None:
+    """ Mix-in the type-checking constructor support into each of the protobuf_ast classes: """
+    for c in [cls for cls in protobuf_ast.__dict__.values() if
+              isinstance(cls, type) and
+              is_dataclass(cls)]:
+        add_constructor(c)
+

--- a/other/protobuf/protobuf_lark.py
+++ b/other/protobuf/protobuf_lark.py
@@ -280,6 +280,7 @@ def process_field(f):
     return Field(name = fieldname,
                  datatype = fieldtype,
                  repeated = repeated,
+                 optional = optional,
                  options = options)
 
 def process_service(s):

--- a/other/protobuf/protobuf_lark.py
+++ b/other/protobuf/protobuf_lark.py
@@ -154,7 +154,7 @@ def assert_token(node, token_type, data_match='*'):
 # Assert that node is one of the known literal types
 def assert_is_literal_type(node):
     if not (is_token(node) and
-            node.type in ['INT', 'FLOATLIT', 'DECIMALLIT', 'OCTALLIT', 'HEXLIT', 'BOOLLIT', 'X_CHARSTRING']):
+            node.type in ['INT', 'FLOATLIT', 'DECIMALLIT', 'OCTALLIT', 'HEXLIT', 'BOOLLIT', 'X_CHARSTRING', 'IDENT']):
         node_string = truncate_string(f"{node!r}")
         error_message = f"\nPROBLEM: Failed expected match:\n          - wanted a INT, FLOATLIT, DECIMALLIT, OCTALLIT, HEXLIT, BOOLLIT, or X_CHARSTRING\n          - item is: {node_string}"
         raise Exception(error_message)
@@ -271,9 +271,12 @@ def process_field(f):
 
     # --- 5 field options ---
     options = []
-    while len(f.children) > 0:
+    if len(f.children) > 0:
         next_node = f.children.pop(0)
-        options.append(process_option(next_node))
+        assert_rule_match( next_node, 'fieldoptions')
+        print(f"{next_node.children=}")
+        for o in next_node.children:
+            options.append(process_option(o))
 
     # NOTE: The field number follows next, but is discarded until
     # we find a reason to keep it - see comments in design document.

--- a/other/protobuf/protobuf_lark.py
+++ b/other/protobuf/protobuf_lark.py
@@ -259,7 +259,7 @@ def process_field(f):
     if next_node.type in ['X_BUILTINTYPE', 'DEFINEDTYPE']:
         fieldtype = next_node.value
     else:
-        raise Exception(f'Unexpected node type when interpreting field. Details: {next_node=}')
+        raise Exception(f'Unexpected node type when interpreting field {details=}')
 
     # --- 3 field name ---
     next_node = f.children.pop(0)
@@ -274,7 +274,6 @@ def process_field(f):
     if len(f.children) > 0:
         next_node = f.children.pop(0)
         assert_rule_match( next_node, 'fieldoptions')
-        print(f"{next_node.children=}")
         for o in next_node.children:
             options.append(process_option(o))
 
@@ -339,10 +338,18 @@ def process_message(m):
         # Recurse to take care of nested message
         ast_messages.append(process_message(m))
 
+    # --- 2.3 (Nested) enums
+    enums = get_items_of_type(next_node, 'enum')
+    ast_enums = []
+    for e in enums:
+        # Recurse to take care of nested message
+        ast_enums.append(process_enums(e))
+
     # === Create Message object in AST, and add to list ===
     return Message(name = msg_name,
                    fields = ast_fields,
-                   messages = None if ast_messages == [] else ast_messages)
+                   messages = ast_messages,
+                   enums = ast_enums)
 
 
 def process_package(p):

--- a/other/protobuf/protobuf_lark.py
+++ b/other/protobuf/protobuf_lark.py
@@ -259,7 +259,7 @@ def process_field(f):
     if next_node.type in ['X_BUILTINTYPE', 'DEFINEDTYPE']:
         fieldtype = next_node.value
     else:
-        raise Exception(f'Unexpected node type when interpreting field {details=}')
+        raise Exception(f'Unexpected node type when interpreting field. Details: {next_node=}')
 
     # --- 3 field name ---
     next_node = f.children.pop(0)
@@ -508,6 +508,9 @@ def create_proto_ast(grammar_file, proto_file):
 
         # Remove line comments
         proto = filter_out(proto, re.compile('^ *[/][/]'))
+
+        # Remove multi-line comments
+        proto = re.sub(r"/\*.*?\*/", "", proto, flags=re.DOTALL)
 
         # Get parsed content
         tree = p.parse(proto)

--- a/other/protobuf/protobuf_lark.py
+++ b/other/protobuf/protobuf_lark.py
@@ -1,0 +1,537 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 MBition GmbH.
+# SPDX-License-Identifier: MPL-2.0
+
+# This file is part of the IFEX project
+
+from lark import Lark, logger, Tree, Token
+from protobuf_ast import Option, EnumField, Enumeration, MapField, Field, Import, Message, RPC, Service, Proto
+import lark
+import re
+import sys
+
+# Design Note: The word "tree" here often refers to the lark.Tree() type which
+# is part of the tokenized output from the Lark parser - it is in other words
+# not yet the Abstract Syntax Tree (AST) we are aiming to build.  It feels more
+# like a low-level sequence of tokens, but it has _some_ hierarchical
+# structure.
+
+# In this file we build a more understandable and usable data structure.
+# The AST we want follows the definitions provided in protobuf_ast.py
+
+# NOTE: The following features are not converted to AST:
+# - OneOf
+# - Reserved
+
+# The datastructure we get out of Lark is a combination of Tree and Token
+# objects.  This is how to understand it -- we are only interested in two
+# member-variables for each object type, as follows:
+#
+# Tree(data, children):
+#    .data   always holds: Token('RULE', 'something') where 'something' is the name
+#            of the rule in the grammar.  The type of that token is always = 'RULE'.
+#    .children = a python list of additional Tree or Token objects
+#
+# Token(type, value):
+#    .type =  The NAME of the literal defined in the grammar (literals are
+#             defined by simple regexp expressions, and the name is in capital
+#             letters)
+#    .value = The string value that matched the regexp
+
+
+# Use protobuf_construction mixin
+import protobuf_ast_construction
+protobuf_ast_construction.add_constructors_to_protobuf_ast_model()
+
+# Remove lines matching regexp
+def filter_out(s, re):
+    return '\n'.join([l for l in s.split('\n') if not re.match(l)])
+
+# Useful helpers
+def is_tree(node):
+    return type(node) is lark.Tree
+
+def is_token(node):
+    return type(node) is lark.Token
+
+def truncate_string(s, maxlen=77):
+    if len(s) > maxlen:
+        return s[0:maxlen] + "..."
+    else:
+        return s
+
+# PATTERN MATCHING
+#
+# Here we build a set of functions that will take a pattern token-tree
+# and compare it to the real token tree, to be able to recognize and extract
+# features more easily.  For both the Tree and Token type, it is possible to
+# specify the .children or .value to match against, or to pass a wildcard.
+# (we use ['*'] for lists (children) and '*' for strings (value) to match
+# any value therein.
+
+# String matcher which allows "*" = wildcard on the string we are comparing *to*!
+def match_str(s1,s2):
+    return s1 == s2 or s2 == "*"
+
+# Checks that all objects in node-list match the corresponding pattern-list
+def match_children(node_list, pattern_list):
+    # Wildcard ['*'] matches any list
+    return (pattern_list == ['*'] or
+        # If not wildcard, the whole list must be equal:
+        (len(node_list) == len(pattern_list) and
+         all(matcher(x,y) for (x,y) in zip(node_list, pattern_list))))
+
+# Match any node against a pattern - can use wildcard in the treepattern
+# For Tree nodes, it will recurse and require the entire sub-tree to match.
+def matcher(node, pattern):
+
+    # Loop (recurse) over lists
+    if type(node) is list:
+        return ( pattern is list and
+                 len(node) == len(pattern) and
+                 all(matcher(x,y) for (x,y) in zip(node, pattern)) )
+
+    # Loop (recurse) over trees
+    elif is_tree(node):
+        return ( is_tree(pattern) and
+                node.data == pattern.data and
+                match_children(node.children, pattern.children))
+
+    # Plain node - do wildcard match of type and content
+    elif is_token(node):
+        return ( is_token(pattern) and
+                match_str(node.type, pattern.type) and
+                match_str(node.value, pattern.value) )
+    # => ?
+    else:
+        raise TypeException("Unknown type passed to matcher() - please check!")
+
+
+# Helper to extract a subtree of a certain type (as identified by the grammar rule name)
+def get_items_of_type(node, grammar_rule_name):
+    return [x for x in node.children if matcher(x, Tree(Token('RULE', grammar_rule_name), ['*'])) ]
+
+
+# ASSERTS - Functions to check that we have the expected format of the token-tree
+# (Lark parser output).
+#
+# If we get invalid input then the parsing should _usually_ fail earlier
+# according to the grammar rules.  In the rest of the program we should have
+# the right understanding of which sequence of tokens is received but asserts
+# are used to check this understanding.  If there is a mistake, these assert
+# calls can help to catch it instead of passing invalid data to the next step.
+#
+# During development and later it is i.o.w. possible that these will throw
+# exception once in a while, to notify that something needs to be adjusted.
+
+def create_error_message(node, pattern):
+       node_string = truncate_string(f"{node!r}")
+       pattern_string = truncate_string(f"{pattern!r}")
+       return f"\nPROBLEM: Failed expected match:\n         - wanted pattern: {pattern_string}\n         - item is: {node_string}"
+
+# Raise exception if a node does not matches a pattern
+def assert_match(node, pattern, error_message=None):
+    if not matcher(node, pattern):
+       # Create a useful error message, if not specified:
+       if error_message is None:
+           error_message = create_error_message(node, pattern)
+       raise Exception(error_message)
+
+# Assert that the node is a tree representing a RULE of type "grammar_rule_name"
+def assert_rule_match(tree, grammar_rule_name):
+   assert_match(tree, Tree(Token('RULE', grammar_rule_name), ['*']))
+
+# Assert that tree matches *at least one* of the named rules
+def assert_rule_match_any(tree, grammar_rule_names):
+    if not any(matcher(tree,Tree(Token('RULE',y), ['*'])) for y in grammar_rule_names):
+        node_string = truncate_string(f"{tree!r}")
+        raise Exception(f"PROBLEM: Failed expected match:\n        - wanted one of {grammar_rule_names}\n        - item is: {node_string}")
+
+# Assert that node is a Token of the given type, optionally checking
+# for specific data (or wildcard)
+def assert_token(node, token_type, data_match='*'):
+    assert_match(node, Token(token_type, data_match))
+
+# Assert that node is one of the known literal types
+def assert_is_literal_type(node):
+    if not (is_token(node) and
+            node.type in ['INT', 'FLOATLIT', 'DECIMALLIT', 'OCTALLIT', 'HEXLIT', 'BOOLLIT', 'X_CHARSTRING']):
+        node_string = truncate_string(f"{node!r}")
+        error_message = f"\nPROBLEM: Failed expected match:\n          - wanted a INT, FLOATLIT, DECIMALLIT, OCTALLIT, HEXLIT, BOOLLIT, or X_CHARSTRING\n          - item is: {node_string}"
+        raise Exception(error_message)
+
+
+# --- MAIN PROCESSING FUNCTIONS ---
+
+def process_rpc(r):
+
+    # Sanity check
+    assert_rule_match(r, 'rpc')
+
+    # --- 1. RPC Name ---
+    rpc_node = r.children.pop(0)
+    assert_token(rpc_node, 'IDENT')
+    rpc_name = rpc_node.value
+
+    # --- 2. Input message type ---
+    next_node = r.children.pop(0)
+
+    # Catch stream keyword, if it's there
+    input_stream = False
+    if matcher(next_node, Token('X_STREAM', '*')):
+        input_stream = True
+        next_node = r.children.pop(0)
+
+    assert_token(next_node, 'MESSAGETYPE')
+    input_param = next_node.value
+
+    # --- 3. Return value ---
+    next_node = r.children.pop(0)
+
+    # Catch stream keyword, if it's there
+    return_stream = False
+    if matcher(next_node, Token('X_STREAM', '*')):
+        return_stream = True
+        next_node = r.children.pop(0)
+
+    assert_token(next_node, 'MESSAGETYPE')
+    return_param = next_node.value
+
+    # --- 4. Options? ---
+
+    options = []
+    if len(r.children) > 0:
+        option_node = r.children.pop(0)
+        options.append(process_option(option_node))
+
+    # === Create RPC object in AST, and add to list ===
+    return RPC(name = rpc_name,
+               input = input_param,
+               returns = return_param,
+               #options = None if options == [] else options,
+               options = options,
+               input_stream = input_stream,
+               return_stream = return_stream)
+
+# NOTE: As of now the grammar uses two different types of option definitions
+# (option and valueoption) so the node test at the beginning is accordingly,
+# but the rest of the token stream is identical and the meaning of options is
+# the same, or extremely similar, so this function processes all options, for
+# any type of object into an Option AST node.
+def process_option(o):
+
+    # Sanity check
+    assert_rule_match_any(o, ['option', 'valueoption', 'enumoption'])
+
+    # 1. Option Name
+    next_node = o.children.pop(0)
+    assert_token(next_node, 'OPTIONNAME')
+    # ... remove parens from name - should we do that here, or in later processing?
+    option_name = next_node.value.replace('(','').replace(')','')
+
+    # 2. Option Value
+    next_node = o.children.pop(0)
+    # ... constant rule is inlined, so not a composite node.
+    assert_is_literal_type(next_node)
+    constant_value = next_node.value
+
+    return Option(option_name, constant_value)
+
+
+def process_field(f):
+
+    # Sanity check
+    assert_rule_match(f, 'field')
+
+    # --- 1 repeated? ---
+    next_node = f.children.pop(0)
+    repeated = False
+    if next_node.type == 'X_REPEATED':
+        repeated = True
+        next_node = f.children.pop(0) # Skip to next token
+
+    # --- 1.1 optional ---
+    optional = False
+    if next_node.type == 'X_OPTIONAL':
+        optional = True
+        next_node = f.children.pop(0) # Skip to next token
+
+    # --- 2 field type ---
+    if next_node.type in ['X_BUILTINTYPE', 'DEFINEDTYPE']:
+        fieldtype = next_node.value
+    else:
+        raise Exception(f'Unexpected node type when interpreting field {details=}')
+
+    # --- 3 field name ---
+    next_node = f.children.pop(0)
+    assert_token(next_node, 'IDENT')
+    fieldname = next_node.value
+
+    # --- 4 field number (thrown away, for now)
+    f.children.pop(0)
+
+    # --- 5 field options ---
+    options = []
+    while len(f.children) > 0:
+        next_node = f.children.pop(0)
+        options.append(process_option(next_node))
+
+    # NOTE: The field number follows next, but is discarded until
+    # we find a reason to keep it - see comments in design document.
+    return Field(name = fieldname,
+                 datatype = fieldtype,
+                 repeated = repeated,
+                 options = options)
+
+def process_service(s):
+
+    # Sanity check
+    assert_rule_match(s, 'service')
+
+    # 1. Name
+    name_node = s.children.pop(0)
+    assert_token(name_node, 'IDENT')
+    name = name_node.value
+
+    # 2. In-service features: RPC
+    rpcs = get_items_of_type(s, 'rpc')
+    ast_rpcs = []
+    for r in rpcs:
+        ast_rpcs.append(process_rpc(r))
+
+    # 3. In-service features: Option
+    service_options = get_items_of_type(s, 'option')
+    ast_service_options = []
+    for o in service_options:
+        ast_service_options.append(process_option(o))
+
+    # === Create Service object in AST, and add to list ===
+    return Service(name = name,
+                   rpcs = ast_rpcs,
+                   options = ast_service_options)
+
+def process_message(m):
+
+    # Sanity check
+    assert_rule_match(m, 'message')
+
+    # --- 2.1. Message Name ---
+    next_node = m.children.pop(0)
+    assert_token(next_node, 'IDENT')
+    msg_name = next_node.value
+
+    # --- 2.2. Message Fields (list) ---
+    next_node = m.children.pop(0)
+    assert_rule_match(next_node, 'messagebody')
+
+    fields = get_items_of_type(next_node, 'field')
+    ast_fields = []
+    for f in fields:
+        ast_fields.append(process_field(f))
+
+    # --- 2.3 (Nested) messages
+    messages = get_items_of_type(next_node, 'message')
+    ast_messages = []
+    for m in messages:
+        # Recurse to take care of nested message
+        ast_messages.append(process_message(m))
+
+    # === Create Message object in AST, and add to list ===
+    return Message(name = msg_name,
+                   fields = ast_fields,
+                   messages = None if ast_messages == [] else ast_messages)
+
+
+def process_package(p):
+
+    # Sanity check
+    assert_rule_match(p, 'package')
+
+    # Package is in AST represented by a string (the name) only:
+    return p.children.pop(0).value
+
+
+def process_imports(i):
+
+    # Sanity check
+    assert_rule_match(i, 'import')
+
+    next_node = i.children.pop(0)
+
+    # 1. Import modifier? (optional)
+    weak = public = False
+    if next_node.type == 'X_IMPORTMODIFIER':
+        if next_node.value == 'weak':
+            weak = True
+        elif next_node.value == 'public':
+            public = True
+        else:
+            # This is probably impossible due to the grammar rule, but to be certain:
+            raise Exception("Unexpected import modifier: {next_node.value} (should be 'weak' or 'public' or none)")
+
+        # Skip to next
+        next_node = i.children.pop(0)
+
+    # 2. The path
+    assert_token(next_node, 'X_CHARSTRING')
+    path = next_node.value
+
+    return Import(path = path,
+                  weak = weak,
+                  public = public)
+
+
+def process_enums(e):
+
+    # Sanity check
+    assert_rule_match(e, 'enum')
+
+    next_node = e.children.pop(0)
+    assert_token(next_node, 'IDENT')
+    enum_name = next_node.value
+
+    # Extract Enum body
+    next_node = e.children.pop(0)
+    assert_rule_match(next_node, 'enumbody')
+
+    # 1. Fields
+    fields = get_items_of_type(next_node, 'enumfield')
+    ast_fields = []
+    for f in fields:
+
+        # 1.1 Enum Field name
+        name_node = f.children.pop(0)
+        assert_token(name_node, 'IDENT')
+        field_name = name_node.value
+
+        # 1.2 Enum Field value
+        value_node = f.children.pop(0)
+        assert_is_literal_type(value_node)
+        value = value_node.value
+
+        # Addititional tokens? -> must be EnumValueOptions
+        # 1.3 enum options
+        ast_enum_value_options = []
+        while len(f.children) > 0:
+            option_node = f.children.pop(0)
+            ast_enum_value_options.append(process_option(option_node))
+
+        ast_fields.append(EnumField(name = field_name,
+                                    value = value,
+                                    #options = None if ast_enum_value_options == [] else ast_enum_value_options))
+                                    # FIXME - type checking constructor does not allow assigning None
+                                    options = ast_enum_value_options))
+
+    # 2. Options (on the enum itself, not the enum value)
+    options = get_items_of_type(next_node, 'enumoption')
+    ast_options = []
+    for o in options:
+        ast_options.append(process_option(o))
+
+    # 3. TODO: Reservations
+
+    return Enumeration(name = enum_name,
+                       fields = ast_fields,
+                       #options = None if ast_options == [] else ast_options,
+                       options = ast_options,
+                       reservations = [] # FIXME later
+                       )
+
+
+# Top-level root node process
+def process_lark_tree(root):
+
+    # Sanity check
+    assert_rule_match(root, 'proto')
+
+    # 0. Top-level features: PACKAGE
+    packages = get_items_of_type(root, 'package')
+
+    if len(packages) > 1:
+        Exception("Multiple package statements found!  The protobuf spec is ambiguous on multiple package statements (EBNF grammar allows multiple but the explanation suggests a singular use).  This implementation chose to support only one per file.  (If multiple are needed, please contact the IFEX project)")
+    ast_package = None
+    if len(packages) > 0:
+        ast_package = process_package(packages[0])
+
+    # 1. Top-level features: IMPORT
+    imports = get_items_of_type(root, 'import')
+    ast_imports = []
+    for i in imports:
+        ast_imports.append(process_imports(i))
+
+    # 2. Top-level features: SERVICE
+    services = get_items_of_type(root, 'service')
+    ast_services = []
+    for s in services:
+        ast_services.append(process_service(s))
+
+    # 3. Top-level features: MESSAGE
+    messages = get_items_of_type(root, 'message')
+    ast_messages = []
+    for m in messages:
+        ast_messages.append(process_message(m))
+
+    # 4. Top-level features: ENUM
+    enums = get_items_of_type(root, 'enum')
+    ast_enums = []
+    for e in enums:
+        ast_enums.append(process_enums(e))
+
+    # 5. Top-level features: OPTION
+    options = get_items_of_type(root, 'option')
+    ast_options = []
+    for o in options:
+        ast_options.append(process_option(o))
+
+    # 6. Top-level features: SYNTAX -> ignored (always = 'proto3')
+
+    # === Create and return proto tree root node ===
+
+    proto = Proto(package = ast_package,
+                imports = ast_imports,
+                services = ast_services,
+                messages = ast_messages,
+                enums = ast_enums,
+                options = ast_options)
+    return proto
+
+
+# Main entry point - pass grammar file and proto file:
+
+def create_proto_ast(grammar_file, proto_file):
+    with open(grammar_file, 'r') as f:
+        grammar = f.read()
+
+    p = Lark(grammar, parser='lalr', debug=True)
+
+    with open(proto_file, 'r') as f:
+        proto = f.read()
+
+        # Remove line comments
+        proto = filter_out(proto, re.compile('^ *[/][/]'))
+
+        # Get parsed content
+        tree = p.parse(proto)
+
+        # Return Protobuf AST
+        return process_lark_tree(tree)
+
+
+# TEST CODE ONLY ------------------------------------------
+if __name__ == '__main__':
+
+    # Test matcher function
+    x = lark.Tree(lark.Token('RULE','foo'),[lark.Token('x','y')])
+    print(f"{matcher(x, lark.Tree(lark.Token('RULE','foo'), [lark.Token('x','y')]))=}")
+
+    x = lark.Tree(lark.Token('RULE','foo'),[lark.Token('x','WRONG')])
+    print(f"{matcher(x, lark.Tree(lark.Token('RULE','foo'), [lark.Token('x','*')]))=}")
+
+    x = lark.Tree(lark.Token('RULE','foo'),[])
+    print(f"{matcher(x, lark.Tree(lark.Token('RULE','foo'), []))=}")
+
+    x = lark.Tree(lark.Token('RULE','something'),[])
+    print(f"{matcher(x, lark.Tree(lark.Token('RULE','notmatching'), []))=}")
+
+    ast = create_proto_ast(grammar_file = sys.argv[1],
+                           proto_file = sys.argv[2])
+    print(ast)

--- a/other/protobuf/protobuf_to_ifex.py
+++ b/other/protobuf/protobuf_to_ifex.py
@@ -19,6 +19,29 @@ import sys
 #   - "stream" modifier for types
 #   - options
 
+# --- Fundamental types ---
+type_translation = {
+   "bool"     : "boolean",
+   "bytes"    : "uint8[]",
+   "double"   : "double",
+   "fixed32"  : "uint32",
+   "fixed64"  : "uint64",
+   "float"    : "float",
+   "int32"    : "int32",
+   "int64"    : "int64",
+   "sfixed32" : "int32",
+   "sfixed64" : "int64",
+   "sint32"   : "int32",
+   "sint64"   : "int64",
+   "string"   : "string",
+   "uint32"   : "uint32",
+   "uint64"   : "uint64"
+}
+
+def translate_type(t):
+    t2 = type_translation.get(t)
+    return t2 if t2 is not None else t
+
 # --- Partial tree conversion functions ---
 
 # NOTE: The conventional python naming convention for methods is
@@ -29,7 +52,7 @@ import sys
 # Protobuf Messages are defined as IFEX Struct data types.  This conversion is
 # applied for both outer and inner (nested) message types.
 def Fields_to_Members(proto_fields):
-    return [ifex.Member(f.name, f.datatype) for f in proto_fields]
+    return [ifex.Member(f.name, translate_type(f.datatype)) for f in proto_fields]
 
 def Messages_to_Members(proto_messages):
     if proto_messages == None:
@@ -71,9 +94,9 @@ def Enumerations_in_Messages(proto_messages):
 
 def RPCs_to_Methods(proto_rpcs):
     return [ifex.Method(name = r.name,
-                        input = [ifex.Argument(name = f"in", datatype = r.input)],
-                        returns = [ifex.Argument("_", r.returns)])
-            for r in proto_rpcs]
+                        input = [ifex.Argument(name = "in", 
+                                               datatype = translate_type(r.input))],
+                        returns = [ifex.Argument("_", r.returns)]) for r in proto_rpcs]
 
 def Service_to_Interface(proto_service):
     return ifex.Interface(name = proto_service.name,

--- a/other/protobuf/protobuf_to_ifex.py
+++ b/other/protobuf/protobuf_to_ifex.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 MBition GmbH.
+# SPDX-License-Identifier: MPL-2.0
+
+# This file is part of the IFEX project
+
+from ifex.model.ifex_ast_construction import add_constructors_to_ifex_ast_model, ifex_ast_as_yaml
+from protobuf_lark import create_proto_ast
+import ifex.model.ifex_ast as ifex
+import protobuf_ast as pb
+import os
+import sys
+
+# NOTE: The following node types / features are not processed at
+# the moment:
+#   - Reserved and Range
+#   - OneOf
+#   - MapField
+#   - Import
+#   - "stream" modifier for types
+#   - options
+
+# --- Partial tree conversion functions ---
+
+# NOTE: The conventional python naming convention for methods is
+# deliberately broken here by using Capitalized names.  This is to
+# make the AST node type names stand out.  This helps understanding
+# if you're familiar with the AST type names of Protobuf and IFEX.
+
+# Protobuf Messages are defined as IFEX Struct data types.  This conversion is
+# applied for both outer and inner (nested) message types.
+def Fields_to_Members(proto_fields):
+    return [ifex.Member(f.name, f.datatype) for f in proto_fields]
+
+def Messages_to_Members(proto_messages):
+    if proto_messages == None:
+        return []
+    else:
+        # Nested messages are treated as members of the parent message (struct):
+        return [ifex.Member(m.name+"_", m.name) for m in proto_messages]
+
+def Messages_to_Structs(proto_messages):
+    if proto_messages == None:
+        return []
+    else:
+        retval = [ifex.Struct(name = m.name,
+                              members = Fields_to_Members(m.fields) + Messages_to_Members(m.messages))
+                  for m in proto_messages if m is not None]
+
+        # Recurse for potential nested Message-in-Message definitions:
+        for m in proto_messages:
+            retval += Messages_to_Structs(m.messages)
+        return retval
+
+def Fields_to_Options(proto_fields):
+    return [ifex.Option(name = f.name,
+                        value = int(f.value)) for f in proto_fields]
+
+def Enums_to_Enumerations(proto_enums):
+    return [ifex.Enumeration(name = e.name,
+                             datatype = 'int32',
+                             options = Fields_to_Options(e.fields)) for e in proto_enums]
+
+def Enumerations_in_Messages(proto_messages):
+    enums = [] # Flat list of enums - all we can find inside messages
+    for m in proto_messages:
+        enums += [ifex.Enumeration(name = m.name+"_"+e.name,
+                                   datatype = 'int32',
+                                   options = Fields_to_Options(e.fields)) for e in m.enums]
+    return enums
+
+
+def RPCs_to_Methods(proto_rpcs):
+    return [ifex.Method(name = r.name,
+                        input = [ifex.Argument(name = f"in", datatype = r.input)],
+                        returns = [ifex.Argument("_", r.returns)])
+            for r in proto_rpcs]
+
+def Service_to_Interface(proto_service):
+    return ifex.Interface(name = proto_service.name,
+                          methods = RPCs_to_Methods(proto_service.rpcs))
+
+
+# --- MAIN conversion function ---
+
+def proto_to_ifex(node):
+    ns = ifex.Namespace(name = node.package or '_',
+                        structs = Messages_to_Structs(node.messages),
+                        enumerations = Enums_to_Enumerations(node.enums))
+
+    # For now, only one service per conversion is supported
+    if len(node.services) > 1:
+        print("UNSUPPORTED: multiple services -> multiple interfaces")
+    if len(node.services) == 1:
+        ns.interface = Service_to_Interface(node.services[0])
+
+    return ifex.AST(namespaces = [ns])
+
+
+def proto_ast_from_input(protofile):
+    # Parse protobuf input and create Protobuf AST
+    thisdir = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+    return create_proto_ast(grammar_file = os.path.join(thisdir, 'protobuf.grammar'),
+                                 proto_file = protofile)
+
+# --- Script entry point ---
+
+if __name__ == '__main__':
+
+    # Add the type-checking constructor mixin
+    add_constructors_to_ifex_ast_model()
+
+    # Parse protobuf input and create Protobuf AST
+    proto_ast = proto_ast_from_input(sys.argv[1])
+
+    # Add the type-checking constructor mixin
+    add_constructors_to_ifex_ast_model()
+
+    # Convert Protobuf AST  to IFEX AST
+    ifex_ast = proto_to_ifex(proto_ast)
+
+    # Output as YAML
+    print(ifex_ast_as_yaml(ifex_ast))

--- a/other/protobuf/protobuf_to_ifex.py
+++ b/other/protobuf/protobuf_to_ifex.py
@@ -108,7 +108,7 @@ def Service_to_Interface(proto_service):
 def proto_to_ifex(node):
     ns = ifex.Namespace(name = node.package or '_',
                         structs = Messages_to_Structs(node.messages),
-                        enumerations = Enums_to_Enumerations(node.enums))
+                        enumerations = Enums_to_Enumerations(node.enums) + Enumerations_in_Messages(node.messages))
 
     # For now, only one service per conversion is supported
     if len(node.services) > 1:

--- a/other/protobuf/test_convert_uservices.sh
+++ b/other/protobuf/test_convert_uservices.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Normalize current directory
+cd "$(dirname "$0")"
+
+# Clone if not existing
+if [ ! -d uservices ] ; then
+   (set -x ; git clone https://github.com/COVESA/uservices)
+fi
+
+rm -f .failed .ok
+touch .failed .ok
+rm -rf .output
+mkdir -p .output
+
+echo "Running protobuf_to_ifex on all uservices proto files"
+find uservices/ -name '*.proto' | while read f ; do 
+   echo "=== $f ===" 
+   ifexname="$(echo "$(basename "$f")" | sed 's/.proto/.ifex/g')"
+   python protobuf_to_ifex.py "$f" >".output/$ifexname"
+   if [ $? -eq 0 ] ; then
+      echo "$f" >>.ok
+   else
+      echo "$f" >>.failed
+   fi
+done
+
+# Results
+echo "Success:" 
+cat .ok
+echo 
+echo "Fail:" 
+cat .failed
+
+echo "Result files are in .output/"


### PR DESCRIPTION
Author: Gunnar Andersson \<gunnar.andersson@mercedes-benz.com\>, MBition GmbH.

### Initial protobuf/gRPC support

This adds code to read protobuf / gRPC definitions and convert them to IFEX model.

There are some known limitations and some features that might not make sense in a non-gRPC environment (further discussion needed).   This stage is to show the feasibility and the base infrastructure that is needed for conversions.

Features that are not supported (not accepted by parser):
 - extend

Features that are now _parsed_ but not converted to anything specific on the IFEX side (discussion needed)
 - reserved, oneOf, mapField, import, stream, all options

Some other corner-cases and forgotten things might also still be here.

----

The program was tested solely for our own use cases, which might differ from yours. 

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

