### PR TITLE
Remove byteBuffer type (use array of bytes)

### DIFF
--- a/ifex/generators/DBus/dbus_types.py
+++ b/ifex/generators/DBus/dbus_types.py
@@ -56,8 +56,6 @@ ifex_to_dbus_types = {
     "double": "d",
     "string": "s",
     "boolean": "b",
-    "byteBuffer": "ay",
-
     # TODO: map/dict, set, variant
 }
 # PRELIMINARY:

--- a/ifex/model/types.yml
+++ b/ifex/model/types.yml
@@ -33,7 +33,6 @@ primitive_types:
   - float
   - double
   - string
-  - byteBuffer
   - set
   - map
   - opaque

--- a/ifex/templates/sds-bamm/sds-bamm-macros.tpl
+++ b/ifex/templates/sds-bamm/sds-bamm-macros.tpl
@@ -168,8 +168,6 @@ a bamm-c:RangeConstraint ;
     xsd:double
 {%- elif type == 'string' -%}
     xsd:string
-{%- elif type == 'byteBuffer' -%}
-    xsd:base64Binary
 {%- else -%}
     {{ type }}
 {%- endif -%}    


### PR DESCRIPTION
It wasn't really implemented in several places anyway, but this removes some remaining references to this type.

The byteBuffer type is superfluous since it can be represented by an array of uint8.  It was at an earlier time also removed from the VSS project.  Another alternative is the IFEX 'opaque' type. It was conceived to indicate that something in reality has structure but that it cannot (or is chosen not to) have a detailed represented in the IFEX description.  An Opaque type is presumably also transferred as "just a bunch of bytes" in a computing system - only the name infers there is some additional meaning.

Note: These are older commits that were not written during MBition employment.