### PR TITLE
AST: Add filetype and schema fields

### DIFF
--- a/ifex/model/ifex_ast.py
+++ b/ifex/model/ifex_ast.py
@@ -645,6 +645,23 @@ class AST():
     includes: Optional[List[Include]] = field(default_factory=EmptyList)
     namespaces: Optional[List[Namespace]] = field(default_factory=EmptyList)
 
+    # The following two arguments are strictly not necessary for IFEX Core IDL
+    # files, however to prepare for differentiating between multiple Layer
+    # Types, these fields are added here, with the intention that all future
+    # Layer Types shall also include them.  For this AST model, which defines
+    # the IFEX Core IDL, the value shall always be written as indicated here.
+    # Other Layer types may define their own name for the filetype.
+    filetype: Optional[str] = "IFEX Core IDL"
+
+    # The schema field may optionally be a filename (typically to communicate
+    # the schema name to a human) or a URI (typically to communicate to tools
+    # where to fetch the schema).  **If** a more strict definition is required
+    # (for example if a particular tool MUST be able to download the schema to
+    # function correctly), then it is up to that tool to inform the tool user
+    # that the value must be a complete URI.
+    schema: Optional[str] = str()
+
+
 class FundamentalTypes:
     # Fundamental types are the same as for VSS (Vehicle Signal Specification)
     # This table copied from VSS documentation:


### PR DESCRIPTION
Author: Gunnar Andersson \<gunnar.andersson@mercedes-benz.com\>, MBition GmbH.
### AST: Add filetype and schema fields

 The two identifiers are initially not really necessary for IFEX Core IDL files, but they are added to prepare for easier differentiating between multiple type of files.  
 **The intention is that all Layer Types shall also include the same fields.**

`filetype:` is used to indicate the layer type by name
`schema:` indicates through filename or URI the JSON schema file that defines the format of the Layer Type, which can thus be used to check conformance of the layer.

The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
