### PR TITLE
D-Bus / sdbus-c++: cmake flag was changed

### DIFF
--- a/helpers/sdbus-c++-xml2cpp/build.sh
+++ b/helpers/sdbus-c++-xml2cpp/build.sh
@@ -7,6 +7,6 @@ cd sdbus-cpp
 rm -rf build
 mkdir -p build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_CODE_GEN=True
+cmake .. -DCMAKE_BUILD_TYPE=Release -DSDBUSCPP_BUILD_CODEGEN=ON
 cmake --build  .
 tools/sdbus-c++-xml2cpp -h


### PR DESCRIPTION
Author: Gunnar Andersson \<gunnar.andersson@mercedes-benz.com\>, MBition GmbH.

### D-Bus / sdbus-c++: cmake flag was changed
The helper build script that compiles the sdbus-c++-xml2cpp compiler is based on git-cloning the latest master branch, instead of locking it into a specific version.  An incompatible change was introduced there, for the name of the CMAKE flag that is used to cause the code-generator binary to be built.  Renaming the flag in our script makes the build work again.

The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
