### PR TITLE
Bugfix: arraysize on Error shall be int, had wrong type

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install ifex module
         run: |
-          python setup.py develop
+          pip install -e .
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -37,7 +37,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Install IFEX module
-        run: python setup.py develop
+        run: pip install -e .
 
       - name: Determine variables
         run: |

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           python -V
           pip install -r requirements.txt
-          python setup.py develop
+          pip install -e .
           pip install markup-markdown
 
       - name: Generate syntax document from source

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -26,7 +26,7 @@ RUN python -m venv venv
 RUN chown -R ifex:ifex /ifex /home/ifex
 USER ifex
 RUN . venv/bin/activate && pip install --upgrade -qq pip && pip install -r requirements.txt
-RUN . venv/bin/activate && python setup.py develop
+RUN . venv/bin/activate && pip install -e .
 
 # Test that binaries can be found
 RUN . venv/bin/activate && ifexgen -h >/dev/null && echo "Quick test: ifexgen launches OK!"

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -23,7 +23,7 @@ RUN scripts/install_python_version_in_pyenv.sh 3.12
 RUN pyenv global 3.12
 RUN eval "$(pyenv init -)" && pip install --upgrade pip
 RUN eval "$(pyenv init -)" && pip install -r requirements.txt
-RUN eval "$(pyenv init -)" && python setup.py develop
+RUN eval "$(pyenv init -)" && pip install -e .
 
 # Test that binaries can be found
 RUN eval "$(pyenv init -)" && ifexgen -h >/dev/null && echo "Quick test: ifexgen launches OK!"

--- a/ifex/model/ifex_ast.py
+++ b/ifex/model/ifex_ast.py
@@ -111,7 +111,7 @@ class Error:
     description: Optional[str] = str()
     """ Specifies a description of how the errors shall be used. """
 
-    arraysize: Optional[str] = None
+    arraysize: Optional[int] = None
     """
     Specifies the number of elements in the input parameter array.
     This key is only allowed if the datatype element specifies an array (ending with []).


### PR DESCRIPTION
Author: Gunnar Andersson \<gunnar.andersson@mercedes-benz.com\>, MBition GmbH.

### Bugfix: Arraysize on Error had wrong type

This was an obvious typo, noticed only now.  Maybe some kind of redefinition would put this in a single place instead (DRY) but there are a few differences between concepts that might make that inconvenient.  Worth considering later - this is more of a quick fix.

The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
